### PR TITLE
IT-692: Stop false positives on substrings

### DIFF
--- a/botblocker.go
+++ b/botblocker.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 
 	"net/http"
 	"net/netip"
@@ -197,7 +198,11 @@ func (b *BotBlocker) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	agent := strings.ToLower(req.UserAgent())
-	blocked, badAgent := b.shouldBlockAgent(agent)
+	blocked, badAgent, err := b.shouldBlockAgent(agent)
+	if err != nil {
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
 	if blocked {
 		log.Infof("blocked request with user agent \"%v\" because it contained \"%v\"", agent, badAgent)
 		http.Error(rw, "blocked", http.StatusForbidden)
@@ -216,14 +221,23 @@ func (b *BotBlocker) shouldBlockIp(addr netip.Addr) bool {
 	return false
 }
 
-func (b *BotBlocker) shouldBlockAgent(userAgent string) (bool, string) {
+func (b *BotBlocker) shouldBlockAgent(userAgent string) (bool, string, error) {
 	userAgent = strings.ToLower(strings.TrimSpace(userAgent))
 	for _, badAgent := range b.userAgentBlockList {
+		// fast check with contains
 		if strings.Contains(userAgent, badAgent) {
-			return true, badAgent
+			// verify with regex
+			pattern := fmt.Sprintf(`(?:\b)%s(?:\b)`, badAgent)
+			matched, err := regexp.Match(pattern, []byte(userAgent))
+			if err != nil {
+				return false, "", fmt.Errorf("failed to check user agent %s: %e", userAgent, err)
+			}
+			if matched {
+				return true, badAgent, nil
+			}
 		}
 	}
-	return false, ""
+	return false, "", nil
 }
 
 func getTimer(startTime time.Time) func() {

--- a/botblocker.go
+++ b/botblocker.go
@@ -191,7 +191,7 @@ func (b *BotBlocker) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	if b.shouldBlockIp(remoteAddrPort.Addr()) {
-		log.Infof("blocked request with from IP %v", remoteAddrPort.Addr())
+		log.Infof("blocked request with from IP \"%v\"", remoteAddrPort.Addr())
 		http.Error(rw, "blocked", http.StatusForbidden)
 		return
 	}
@@ -199,7 +199,7 @@ func (b *BotBlocker) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	agent := strings.ToLower(req.UserAgent())
 	blocked, badAgent := b.shouldBlockAgent(agent)
 	if blocked {
-		log.Infof("blocked request with user agent %v because it contained %v", agent, badAgent)
+		log.Infof("blocked request with user agent \"%v\" because it contained \"%v\"", agent, badAgent)
 		http.Error(rw, "blocked", http.StatusForbidden)
 		return
 	}

--- a/botblocker_test.go
+++ b/botblocker_test.go
@@ -150,16 +150,20 @@ func TestShouldAllowIpCidr(t *testing.T) {
 }
 
 func TestShouldBlockUserAgent(t *testing.T) {
+	badAgent := "nintendobrowser"
 	botBlocker := BotBlocker{
 		userAgentBlockList: []string{
-			"nintendobrowser",
+			badAgent,
 		},
 	}
-	badUserAgent := "Mozilla/5.0 (Nintendo WiiU) AppleWebKit/536.30 (KHTML, like Gecko) NX/3.0.4.2.12 NintendoBrowser/4.3.1.11264.US"
+	requestAgent := "Mozilla/5.0 (Nintendo WiiU) AppleWebKit/536.30 (KHTML, like Gecko) NX/3.0.4.2.12 NintendoBrowser/4.3.1.11264.US"
 
-	blocked := botBlocker.shouldBlockAgent(badUserAgent)
+	blocked, blockedAgent := botBlocker.shouldBlockAgent(requestAgent)
 	if !blocked {
-		t.Fatalf("botBlocker.shouldBlockAgent(%s) = %t; want true", badUserAgent, blocked)
+		t.Fatalf("botBlocker.shouldBlockAgent(%s) = %t; want true", requestAgent, blocked)
+	}
+	if blockedAgent != badAgent {
+		t.Fatalf("botBlocker.shouldBlockAgent(%s) = %s; want \"\"", requestAgent, blockedAgent)
 	}
 }
 
@@ -171,8 +175,11 @@ func TestShouldAlowUserAgent(t *testing.T) {
 	}
 	userAgent := "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
 
-	blocked := botBlocker.shouldBlockAgent(userAgent)
+	blocked, badAgent := botBlocker.shouldBlockAgent(userAgent)
 	if blocked {
 		t.Fatalf("botBlocker.shouldBlockAgent(%s) = %t; want false", userAgent, blocked)
+	}
+	if badAgent != "" {
+		t.Fatalf("botBlocker.shouldBlockAgent(%s) = %s; want \"\"", userAgent, badAgent)
 	}
 }

--- a/botblocker_test.go
+++ b/botblocker_test.go
@@ -158,7 +158,10 @@ func TestShouldBlockUserAgent(t *testing.T) {
 	}
 	requestAgent := "Mozilla/5.0 (Nintendo WiiU) AppleWebKit/536.30 (KHTML, like Gecko) NX/3.0.4.2.12 NintendoBrowser/4.3.1.11264.US"
 
-	blocked, blockedAgent := botBlocker.shouldBlockAgent(requestAgent)
+	blocked, blockedAgent, err := botBlocker.shouldBlockAgent(requestAgent)
+	if err != nil {
+		t.Fatalf("botBlocker.shouldBlockAgent(%s) returned a none nil error", requestAgent)
+	}
 	if !blocked {
 		t.Fatalf("botBlocker.shouldBlockAgent(%s) = %t; want true", requestAgent, blocked)
 	}
@@ -167,7 +170,7 @@ func TestShouldBlockUserAgent(t *testing.T) {
 	}
 }
 
-func TestShouldAlowUserAgent(t *testing.T) {
+func TestShouldAllowUserAgent(t *testing.T) {
 	botBlocker := BotBlocker{
 		userAgentBlockList: []string{
 			"nintendobrowser",
@@ -175,7 +178,30 @@ func TestShouldAlowUserAgent(t *testing.T) {
 	}
 	userAgent := "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
 
-	blocked, badAgent := botBlocker.shouldBlockAgent(userAgent)
+	blocked, badAgent, err := botBlocker.shouldBlockAgent(userAgent)
+	if err != nil {
+		t.Fatalf("botBlocker.shouldBlockAgent(%s) returned a non nil error", userAgent)
+	}
+	if blocked {
+		t.Fatalf("botBlocker.shouldBlockAgent(%s) = %t; want false", userAgent, blocked)
+	}
+	if badAgent != "" {
+		t.Fatalf("botBlocker.shouldBlockAgent(%s) = %s; want \"\"", userAgent, badAgent)
+	}
+}
+
+func TestShouldAllowUserAgentSubstring(t *testing.T) {
+	botBlocker := BotBlocker{
+		userAgentBlockList: []string{
+			"obot",
+		},
+	}
+	userAgent := "mozilla/5.0+(compatible; uptimerobot/2.0; http://www.uptimerobot.com/)"
+
+	blocked, badAgent, err := botBlocker.shouldBlockAgent(userAgent)
+	if err != nil {
+		t.Fatalf("botBlocker.shouldBlockAgent(%s) returned a non nil error", userAgent)
+	}
 	if blocked {
 		t.Fatalf("botBlocker.shouldBlockAgent(%s) = %t; want false", userAgent, blocked)
 	}


### PR DESCRIPTION
 Fixes an issue where a bad user agent that is a substring of a good bot was
 blocking the good bot. Fixed by verifying with regex and word boundaries.

Also fixed:
- An issue where the blocked agent was not being reported properly
- The reported time included the service's response time, now it only contains the request checking time.